### PR TITLE
Create ~/.gitshots if it doesn't exist. Dump data to json. Optionally don't post anywhere. README improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Setting up your own Gitshots server is as easy as deploying to Heroku (just copy
 
 If you don't want to set up your own Gitshots server, feel free to use [ranman's](http://gitshots.ranman.org) (it's the default).
 
+If you'd rather not post to Gitshots in general, just record to disk, set the GITSHOTS_SERVER_URL to `False`
+
 ## Taking a gitshot on every commit
 
 With your Gitshots server setup, you need to configure your computer to take gitshots.

--- a/post-commit.py
+++ b/post-commit.py
@@ -46,14 +46,19 @@ stats = subprocess.check_output(['git', 'diff', 'HEAD~1', '--numstat'])
 stats = stats.split('\n')
 dstats = [dict(zip(['+', '-', 'f'], line.split('\t'))) for line in stats][:-1]
 data['dstats'] = dstats
-data = json.dumps(data)
-response = requests.post(
-    GITSHOTS_SERVER_URL + '/post_image',
-    files={'photo': ('photo', img)}
-)
-print "Image pushed: {0}".format(response.text)
-response = requests.put(
-    GITSHOTS_SERVER_URL + '/put_commit/' + response.text,
-    data=data
-)
-print "Data pushed: {0}".format(response.text)
+
+with open(imgpath[:-3]+"json", 'w') as f:
+    json.dump(data, f)
+
+if GITSHOTS_SERVER_URL:
+    data = json.dumps(data)
+    response = requests.post(
+        GITSHOTS_SERVER_URL + '/post_image',
+        files={'photo': ('photo', img)}
+    )
+    print "Image pushed: {0}".format(response.text)
+    response = requests.put(
+        GITSHOTS_SERVER_URL + '/put_commit/' + response.text,
+        data=data
+    )
+    print "Data pushed: {0}".format(response.text)


### PR DESCRIPTION
A few miscellaneous improvements.
1. Create the `~/.gitshots` directory if it doesn't exist. This isn't the most robust way to test this, but it will work for the common case.
2. Dump the data to `~/.gitshots/timestamp.json` for later use.
3. If the environment `GITSHOTS_SERVER_URL` is set to `False` don't post the image at all, just save it locally.
4. Added more details to the README for client side setup, particularly that `requests` and `imagesnap` are required.
