### PR TITLE
Adds warning if correct img command not installed

### DIFF
--- a/post-commit.py
+++ b/post-commit.py
@@ -24,7 +24,9 @@ except AttributeError:
 GITSHOTS_PATH = '~/.gitshots/'
 GITSHOTS_SERVER_URL = os.environ.get(
     'GITSHOTS_SERVER_URL', 'http://gitshots.ranman.org')
-GITSHOTS_IMAGE_CMD = 'imagesnap -q '
+
+GITSHOTS_IMAGE_CMD = 'imagesnap'
+GITSHOTS_IMAGE_CMD_ARGS = ['-q']
 
 # ensure directory exists
 if not os.path.exists(os.path.expanduser(GITSHOTS_PATH)):
@@ -33,12 +35,23 @@ if not os.path.exists(os.path.expanduser(GITSHOTS_PATH)):
 # filename is unix epoch time
 filename = str(time.mktime(datetime.now().timetuple()))[:10] + '.jpg'
 imgpath = os.path.abspath(os.path.expanduser(GITSHOTS_PATH + filename))
+GITSHOTS_IMAGE_CMD_ARGS.append(imgpath)
 # this may need to change
-img_command = GITSHOTS_IMAGE_CMD + imgpath
+img_command = [GITSHOTS_IMAGE_CMD] + GITSHOTS_IMAGE_CMD_ARGS
+
 author = getpass.getuser()
 
 print("Taking capture into {0}...".format(imgpath))
-subprocess.check_output(img_command.split(' '), shell=False)
+try:
+    subprocess.check_output(img_command, shell=False)
+except OSError as e:
+    if e.errno == os.errno.ENOENT:
+        msg = "Please run `brew install {cmd}` before using gitshots.".format(
+            cmd=GITSHOTS_IMAGE_CMD
+        )
+        raise Exception(msg)
+    else:
+        raise
 
 with open(imgpath, 'rb') as f:
     img = f.read()


### PR DESCRIPTION
Recently, I had to clear Brew, which deleted imgsnap. I forgot about it, but noticed that gitshots wasn't working. After a couple days, I realized that it was because I didn't have the requisite image taking command (imgsnap). If there had been a nice warning, I would have been able to realize this quicker. Hence this PR.
