### PR TITLE
Fixing echo comand, to enable interpretation backslash-escaped characters

### DIFF
--- a/gitshots/templates/index.html
+++ b/gitshots/templates/index.html
@@ -12,7 +12,7 @@
         <ol>
             <li><code>git config --global init.templatedir '~/.git_template'</code></li>
             <li><code>mkdir -p ~/.git_template/hooks</code></li>
-            <li><code>echo '#!/bin/sh\n/usr/bin/env python2.7 <strong>/FULLPATH/TO/</strong>post-commit.py' >> ~/.git_template/hooks/post-commit</code></li>
+            <li><code>echo -e '#!/bin/sh\n/usr/bin/env python2.7 <strong>/FULLPATH/TO/</strong>post-commit.py' >> ~/.git_template/hooks/post-commit</code></li>
             <li><code>chmod +x ~/.git_template/hooks/post-commit</code></li>
         </ol>
         <li>Run <code>git init</code> in a repo where you want to use the hook!</li>


### PR DESCRIPTION
This fix will avoid some problems in the installation manual at the index project.
Following the documentation of the echo command: http://ss64.com/bash/echo.html the -e will enable the interpretation backslash-escaped characters. 